### PR TITLE
(deps) Update init-tracing-opentelemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "equinix-otel-tools"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-init-tracing-opentelemetry = { version = "0.23", features = [
+init-tracing-opentelemetry = { version = "0.24.1", features = [
   "otlp",
   "tls",
   "tracing_subscriber_ext",


### PR DESCRIPTION
This commit brings in init-tracing-openetelemtry 0.24.1 which fixes a bug where spans might not get sent before program termination.

Updating to this version may require some light code changes to ensure that the guard struct is being
handled correctly to ensure trace flushing.

Fixes #3

Related:
- davidB/tracing-opentelemetry-instrumentation-sdk#184
- davidB/tracing-opentelemetry-instrumentation-sdk#185